### PR TITLE
Improve namespace naming

### DIFF
--- a/aruco/apps/gltf_exporter.cpp
+++ b/aruco/apps/gltf_exporter.cpp
@@ -42,6 +42,8 @@
 
 namespace {
 
+namespace board = bananas::board;
+
 const char *const about{
     "Generate binary glTF and SDF files from a set of ArUco marker placements"};
 const char *const keys{

--- a/aruco/apps/positioner.cpp
+++ b/aruco/apps/positioner.cpp
@@ -63,6 +63,11 @@
 
 namespace {
 
+namespace affine_rotation = bananas::affine_rotation;
+namespace board = bananas::board;
+namespace world = bananas::world;
+namespace visualizer = bananas::visualizer;
+
 const char *const about{"Find camera and box locations from a video"};
 const char *const keys{
     "{env     | <none> | JSON file describing the static environment }"

--- a/aruco/include/bananas_aruco/affine_rotation.h
+++ b/aruco/include/bananas_aruco/affine_rotation.h
@@ -1,5 +1,5 @@
-#ifndef AFFINE_ROTATION_H_
-#define AFFINE_ROTATION_H_
+#ifndef BANANAS_ARUCO_AFFINE_ROTATION_H_
+#define BANANAS_ARUCO_AFFINE_ROTATION_H_
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
@@ -9,7 +9,8 @@
 #include <opencv2/core/matx.hpp>
 #include <opencv2/core/types.hpp>
 
-namespace affine_rotation {
+/// Helpers for working with translations and rotations.
+namespace bananas::affine_rotation {
 
 /// A combination of translation and rotation.
 class AffineRotation {
@@ -40,6 +41,6 @@ void to_json(nlohmann::json &j, const AffineRotation &affine_rotation);
 
 auto from_cv(const cv::Vec3f &rvec, const cv::Vec3f &tvec) -> AffineRotation;
 
-} // namespace affine_rotation
+} // namespace bananas::affine_rotation
 
-#endif // AFFINE_ROTATION_H_
+#endif // BANANAS_ARUCO_AFFINE_ROTATION_H_

--- a/aruco/include/bananas_aruco/board.h
+++ b/aruco/include/bananas_aruco/board.h
@@ -1,5 +1,5 @@
-#ifndef BOARD_H_
-#define BOARD_H_
+#ifndef BANANAS_ARUCO_BOARD_H_
+#define BANANAS_ARUCO_BOARD_H_
 
 #include <vector>
 
@@ -7,7 +7,8 @@
 #include <opencv2/objdetect/aruco_board.hpp>
 #include <opencv2/objdetect/aruco_dictionary.hpp>
 
-namespace board {
+/// Structures and functions related to ArUco boards.
+namespace bananas::board {
 
 struct Board {
     std::vector<std::vector<cv::Point3f>> obj_points;
@@ -18,6 +19,6 @@ struct Board {
 auto to_cv(const cv::aruco::Dictionary &dictionary,
            const Board &board) -> cv::aruco::Board;
 
-} // namespace board
+} // namespace bananas::board
 
-#endif // BOARD_H_
+#endif // BANANAS_ARUCO_BOARD_H_

--- a/aruco/include/bananas_aruco/box_board.h
+++ b/aruco/include/bananas_aruco/box_board.h
@@ -1,5 +1,5 @@
-#ifndef BOX_BOARD_H_
-#define BOX_BOARD_H_
+#ifndef BANANAS_ARUCO_BOX_BOARD_H_
+#define BANANAS_ARUCO_BOX_BOARD_H_
 
 #include <array>
 #include <vector>
@@ -8,7 +8,7 @@
 
 #include <bananas_aruco/board.h>
 
-namespace board {
+namespace bananas::board {
 
 /// Settings defining the location of a single marker relative to a box face.
 struct BoxMarkerSettings {
@@ -65,6 +65,6 @@ void from_json(const nlohmann::json &j, BoxSettings &box_settings);
 /// glTF coordinate system: +X is left, +Y is up and +Z is forward.
 auto make_board(const BoxSettings &settings) -> Board;
 
-} // namespace board
+} // namespace bananas::board
 
-#endif // BOX_BOARD_H_
+#endif // BANANAS_ARUCO_BOX_BOARD_H_

--- a/aruco/include/bananas_aruco/concrete_board.h
+++ b/aruco/include/bananas_aruco/concrete_board.h
@@ -1,5 +1,5 @@
-#ifndef CONCRETE_BOARD_H_
-#define CONCRETE_BOARD_H_
+#ifndef BANANAS_ARUCO_CONCRETE_BOARD_H_
+#define BANANAS_ARUCO_CONCRETE_BOARD_H_
 
 #include <variant>
 
@@ -8,11 +8,11 @@
 #include <bananas_aruco/box_board.h>
 #include <bananas_aruco/grid_board.h>
 
-namespace board {
+namespace bananas::board {
 
 using ConcreteBoard = std::variant<BoxSettings, GridSettings>;
 void from_json(const nlohmann::json &j, ConcreteBoard &board);
 
-} // namespace board
+} // namespace bananas::board
 
-#endif // CONCRETE_BOARD_H_
+#endif // BANANAS_ARUCO_CONCRETE_BOARD_H_

--- a/aruco/include/bananas_aruco/grid_board.h
+++ b/aruco/include/bananas_aruco/grid_board.h
@@ -1,5 +1,5 @@
-#ifndef GRID_BOARD_H_
-#define GRID_BOARD_H_
+#ifndef BANANAS_ARUCO_GRID_BOARD_H_
+#define BANANAS_ARUCO_GRID_BOARD_H_
 
 #include <cstdint>
 
@@ -9,7 +9,7 @@
 
 #include <bananas_aruco/board.h>
 
-namespace board {
+namespace bananas::board {
 
 struct GridSize {
     std::uint32_t num_columns{5};
@@ -35,6 +35,6 @@ auto grid_height(const GridSettings &settings) -> float;
 /// +Y is up and +Z is forward).
 auto make_board(const GridSettings &settings) -> Board;
 
-} // namespace board
+} // namespace bananas::board
 
-#endif // GRID_BOARD_H_
+#endif // BANANAS_ARUCO_GRID_BOARD_H_

--- a/aruco/include/bananas_aruco/mavlink.h
+++ b/aruco/include/bananas_aruco/mavlink.h
@@ -1,11 +1,12 @@
-#ifndef BANANAS_MAVLINK_H_
-#define BANANAS_MAVLINK_H_
+#ifndef BANANAS_ARUCO_MAVLINK_H_
+#define BANANAS_ARUCO_MAVLINK_H_
 
 #include <mavsdk/plugins/mocap/mocap.h>
 
 #include <bananas_aruco/affine_rotation.h>
 #include <bananas_aruco/world.h>
 
+/// Functions helping with MAVLink integration.
 namespace bananas::mavlink {
 
 mavsdk::Mocap::VisionPositionEstimate
@@ -14,4 +15,4 @@ drone_position_estimate(const affine_rotation::AffineRotation &camera_to_drone,
 
 } // namespace bananas::mavlink
 
-#endif // BANANAS_MAVLINK_H_
+#endif // BANANAS_ARUCO_MAVLINK_H_

--- a/aruco/include/bananas_aruco/visualization/visualizer.h
+++ b/aruco/include/bananas_aruco/visualization/visualizer.h
@@ -1,5 +1,5 @@
-#ifndef VISUALIZER_H_
-#define VISUALIZER_H_
+#ifndef BANANAS_ARUCO_VISUALIZER_H_
+#define BANANAS_ARUCO_VISUALIZER_H_
 
 #include <unordered_map>
 #include <unordered_set>
@@ -22,7 +22,8 @@
 #include <bananas_aruco/grid_board.h>
 #include <bananas_aruco/world.h>
 
-namespace visualizer {
+/// World model visualization tools.
+namespace bananas::visualizer {
 
 class Visualizer {
   public:
@@ -77,6 +78,6 @@ class Visualizer {
     std::unordered_set<world::BoardId> forced_visible_{};
 };
 
-} // namespace visualizer
+} // namespace bananas::visualizer
 
-#endif // VISUALIZER_H_
+#endif // BANANAS_ARUCO_VISUALIZER_H_

--- a/aruco/include/bananas_aruco/world.h
+++ b/aruco/include/bananas_aruco/world.h
@@ -1,5 +1,5 @@
-#ifndef WORLD_H_
-#define WORLD_H_
+#ifndef BANANAS_ARUCO_WORLD_H_
+#define BANANAS_ARUCO_WORLD_H_
 
 #include <cstdint>
 #include <optional>
@@ -19,7 +19,8 @@
 #include <bananas_aruco/affine_rotation.h>
 #include <bananas_aruco/board.h>
 
-namespace world {
+/// Structures and functions related to the world model.
+namespace bananas::world {
 
 using BoardId = std::uint32_t;
 using BoardPlacement =
@@ -76,6 +77,6 @@ class World {
     std::vector<cv::aruco::Board> all_boards_{};
 };
 
-} // namespace world
+} // namespace bananas::world
 
-#endif // WORLD_H_
+#endif // BANANAS_ARUCO_WORLD_H_

--- a/aruco/src/affine_rotation.cpp
+++ b/aruco/src/affine_rotation.cpp
@@ -12,7 +12,7 @@
 #include <opencv2/core/matx.hpp>
 #include <opencv2/core/types.hpp>
 
-namespace affine_rotation {
+namespace bananas::affine_rotation {
 
 AffineRotation::AffineRotation()
     : translation_{0.0F, 0.0F, 0.0F}, rotation_{1.0F, 0.0F, 0.0F, 0.0F} {};
@@ -85,4 +85,4 @@ auto from_cv(const cv::Vec3f &rvec, const cv::Vec3f &tvec) -> AffineRotation {
     return {translation, Eigen::Quaternionf{rotation}};
 }
 
-} // namespace affine_rotation
+} // namespace bananas::affine_rotation

--- a/aruco/src/board.cpp
+++ b/aruco/src/board.cpp
@@ -2,11 +2,11 @@
 
 #include <opencv2/objdetect/aruco_board.hpp>
 
-namespace board {
+namespace bananas::board {
 
 auto to_cv(const cv::aruco::Dictionary &dictionary,
            const Board &board) -> cv::aruco::Board {
     return {board.obj_points, dictionary, board.marker_ids};
 }
 
-} // namespace board
+} // namespace bananas::board

--- a/aruco/src/box_board.cpp
+++ b/aruco/src/box_board.cpp
@@ -14,9 +14,11 @@
 
 #include <bananas_aruco/board.h>
 
+namespace bananas::board {
+
 namespace {
 
-auto form_box_face(const board::BoxMarkerSettings &face_settings)
+auto form_box_face(const BoxMarkerSettings &face_settings)
     -> std::array<cv::Point2f, 4> {
     const float half_side{face_settings.side / 2.0F};
     std::array<cv::Point2f, 4> face{cv::Point2f{-half_side, -half_side},
@@ -47,8 +49,6 @@ auto form_box_face(const board::BoxMarkerSettings &face_settings)
 const float quarter_circle{std::atan(1.0F) * 2.0F};
 
 } // namespace
-
-namespace board {
 
 void from_json(const nlohmann::json &j, BoxSettings &box_settings) {
     j.at("size").get_to(box_settings.size);
@@ -120,4 +120,4 @@ auto make_board(const BoxSettings &settings) -> board::Board {
     return {std::move(object_points), std::move(ids)};
 }
 
-} // namespace board
+} // namespace bananas::board

--- a/aruco/src/concrete_board.cpp
+++ b/aruco/src/concrete_board.cpp
@@ -8,7 +8,7 @@
 #include <bananas_aruco/box_board.h>
 #include <bananas_aruco/grid_board.h>
 
-namespace board {
+namespace bananas::board {
 
 void from_json(const nlohmann::json &j, ConcreteBoard &board) {
     const auto type{j.at("type").get<std::string>()};
@@ -21,4 +21,4 @@ void from_json(const nlohmann::json &j, ConcreteBoard &board) {
     }
 }
 
-} // namespace board
+} // namespace bananas::board

--- a/aruco/src/grid_board.cpp
+++ b/aruco/src/grid_board.cpp
@@ -9,7 +9,7 @@
 
 #include <bananas_aruco/board.h>
 
-namespace board {
+namespace bananas::board {
 
 auto grid_width(const GridSettings &settings) -> float {
     return (static_cast<float>(settings.size.num_columns) *
@@ -64,4 +64,4 @@ auto make_board(const GridSettings &settings) -> Board {
     return {std::move(object_points), std::move(ids)};
 }
 
-} // namespace board
+} // namespace bananas::board

--- a/aruco/src/visualization/visualizer.cpp
+++ b/aruco/src/visualization/visualizer.cpp
@@ -31,6 +31,8 @@
 #include <bananas_aruco/grid_board.h>
 #include <bananas_aruco/world.h>
 
+namespace bananas::visualizer {
+
 namespace {
 
 void set_transform(Ogre::SceneNode *node,
@@ -51,8 +53,6 @@ void set_color(Ogre::MaterialPtr material, float reprojection_error) {
 }
 
 } // namespace
-
-namespace visualizer {
 
 Visualizer::KeyHandler::KeyHandler(OgreBites::CameraMan *camera_manager)
     : camera_manager_{camera_manager} {}
@@ -201,4 +201,4 @@ void Visualizer::forceVisible(world::BoardId id) {
     forced_visible_.insert(id);
 }
 
-} // namespace visualizer
+} // namespace bananas::visualizer

--- a/aruco/src/world.cpp
+++ b/aruco/src/world.cpp
@@ -25,6 +25,8 @@
 #include <bananas_aruco/affine_rotation.h>
 #include <bananas_aruco/board.h>
 
+namespace bananas::world {
+
 namespace {
 
 struct PlacementJson {
@@ -37,8 +39,6 @@ struct PlacementJson {
                                                     board_to_world);
 
 } // namespace
-
-namespace world {
 
 void from_json(const nlohmann::json &j, BoardPlacement &placement) {
     const auto placement_vector{j.get<std::vector<PlacementJson>>()};
@@ -185,4 +185,4 @@ void World::recomputeStaticEnvironment() {
     static_environment_ = {obj_points, *dictionary_, ids};
 }
 
-} // namespace world
+} // namespace bananas::world

--- a/aruco/tests/box_board.cpp
+++ b/aruco/tests/box_board.cpp
@@ -18,6 +18,8 @@ using namespace nlohmann::json_literals;
 
 namespace {
 
+namespace board = bananas::board;
+
 // NOLINTNEXTLINE(modernize-use-trailing-return-type)
 MATCHER(PointsEq, std::string{"are "} + (negation ? "not " : "") +
                       "approximately equal points") {

--- a/aruco/tests/grid_board.cpp
+++ b/aruco/tests/grid_board.cpp
@@ -6,6 +6,8 @@
 
 #include <bananas_aruco/grid_board.h>
 
+namespace board = bananas::board;
+
 TEST(GridBoardTest, GridBoardsWork) {
     const board::GridSettings settings{{3, 2}, 1.0F, 0.5F, 5};
     auto board{board::make_board(settings)};

--- a/aruco/tests/mavlink.cpp
+++ b/aruco/tests/mavlink.cpp
@@ -10,6 +10,8 @@
 
 namespace {
 
+namespace affine_rotation = bananas::affine_rotation;
+
 constexpr float pi{3.1415927F};
 // EXPECT_FLOAT_EQ's usage of ULPs gets a bit silly near zero. Let's just use a
 // constant absolute bound instead.


### PR DESCRIPTION
It's better to have a common parent namespace for everything so that the namespaces would not collide with other libraries.